### PR TITLE
chore: configure Travis Slack notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ cache:
 
 notifications:
   email: false
+  slack:
+    on_failure: always
+    on_success: never
+    on_pull_requests: false
+    rooms:
+      secure: mWzYwXXkaPJ/t24kG9gz6hYyRGoGX+zsjKDa+IzjhY4NeMJyzgHyN3x1vWwSXhfG1jQuBTFyT5RTWN8Jfo2Za/XDKYfMXXP5gCMtNkeWdflYWaUC7sAZepRANUB3gzkCTvkc/DOY/FI07xCcLMJoZ7jGiADNakTaWvzdExJUBs6NuhGdIUmOT+chbip02yN7mSPeqyU7/vFqpCxxEoPeNzaNshLufbZUEWgmLm0bm5Uxdo7Yi5rL0/nA7oqXUzzWTtgQEu0mOG4Oqu7oXAki2rLISw8enZwt5/fUbxGgK1J3UB86vgnDrxbTAhuNUuddaSxUuDsg1+3xyRzU74cyKUWnWqL10Tyy9KgDR0A+48w2v8DH/pOvnvfXA+FL0zLtDJ9jPuSK0dFbceRYmolEGMDF53Q/s2W+waC13Bi3nHRQJKYmT+bOnoLABLpfm5fbV/2br4LVTQwiP80HJ+19Vy4lriF55zu1yjESUBzdvvX1Dhp5E3AXZZv6xB0v4gyZZeOoIv6BxqinLauZiS3nM7O9vu1QnFvbo4HH0Df651fyy1kOU5UAAD+CNRgpZ8GMc+EegvnLbS3nzbNOPlkACmhxMNcpEvD6MomcB4UV2dPWAYIQSfrRV5h+iZlNSqCkA2pl3p6TTZhLMvoSxziRzUZZx7GQe/cnUGN6GbzyyRk=
 
 install: true
 script: ./mvnw verify --show-version --batch-mode --errors


### PR DESCRIPTION
This PR adds Slack notifications in Travis builds. We send a message on failure only and not on pull requests.