### PR TITLE
Fix: JetBrains comments and remarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Enables TeamCity integration with Snyk and allows users to test their applicatio
 * [Overview](#overview)
 * [Installation](#installation)
 * [Usage](#usage)
-* [Contributions](#contributons)
+* [Contributions](#contributions)
 * [License](#license)
 
 
@@ -23,7 +23,7 @@ Plugin supports following operations:
 
 ## Installation
 
-You can [download]() the plugin build and install it as an [additional plugin](https://confluence.jetbrains.com/display/TCDL/Installing+Additional+Plugins) for TeamCity 2018.2+.
+You can [download the plugin](https://plugins.jetbrains.com/plugin/12227-snyk-security) and install it as an [additional plugin](https://confluence.jetbrains.com/display/TCDL/Installing+Additional+Plugins) for TeamCity 2018.2+.
 
 
 ## Usage
@@ -52,4 +52,4 @@ We appreciate all kinds of feedback, so please feel free to send a PR or submit 
 
 ## License
 
-//TODO
+This project is licensed under the [Apache License, Version 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # TeamCity Snyk Security Plugin
 
 [![Known Vulnerabilities](https://snyk.io/test/github/snyk/teamcity-snyk-security-plugin/badge.svg)](https://snyk.io/test/github/snyk/teamcity-snyk-security-plugin)
+[![Build Status](https://travis-ci.com/snyk/teamcity-snyk-security-plugin.svg?branch=master)](https://travis-ci.com/snyk/teamcity-snyk-security-plugin)
 
 Enables TeamCity integration with Snyk and allows users to test their applications against the [Snyk vulnerability database](https://snyk.io/vuln).
 

--- a/teamcity-snyk-security-plugin-common/src/main/java/io/snyk/plugins/teamcity/common/SnykSecurityRunnerConstants.java
+++ b/teamcity-snyk-security-plugin-common/src/main/java/io/snyk/plugins/teamcity/common/SnykSecurityRunnerConstants.java
@@ -1,7 +1,7 @@
 package io.snyk.plugins.teamcity.common;
 
 public final class SnykSecurityRunnerConstants {
-  public static final String RUNNER_TYPE = "snykSecurityRunner";
+  public static final String RUNNER_TYPE = "snykSecurity";
   public static final String RUNNER_DISPLAY_NAME = "Snyk Security";
   public static final String RUNNER_DESCRIPTION = "Runner for finding vulnerabilities in your dependencies";
 

--- a/teamcity-snyk-security-plugin-common/src/main/java/io/snyk/plugins/teamcity/common/SnykSecurityRunnerConstants.java
+++ b/teamcity-snyk-security-plugin-common/src/main/java/io/snyk/plugins/teamcity/common/SnykSecurityRunnerConstants.java
@@ -5,16 +5,16 @@ public final class SnykSecurityRunnerConstants {
   public static final String RUNNER_DISPLAY_NAME = "Snyk Security";
   public static final String RUNNER_DESCRIPTION = "Runner for finding vulnerabilities in your dependencies";
 
-  public static final String SEVERITY_THRESHOLD = "snyk.severityThreshold";
-  public static final String MONITOR_PROJECT_ON_BUILD = "snyk.monitorProjectOnBuild";
-  public static final String FILE = "snyk.file";
-  public static final String ORGANISATION = "snyk.organisation";
-  public static final String PROJECT_NAME = "snyk.projectName";
-  public static final String ADDITIONAL_PARAMETERS = "snyk.additionalParameters";
-  public static final String API_TOKEN = "secure:snyk.apiToken";
-  public static final String VERSION = "snyk.version";
-  public static final String USE_CUSTOM_BUILD_TOOL_PATH = "snyk.useCustomBuildToolPath";
-  public static final String CUSTOM_BUILD_TOOL_PATH = "snyk.customBuildToolPath";
+  public static final String SEVERITY_THRESHOLD = "severityThreshold";
+  public static final String MONITOR_PROJECT_ON_BUILD = "monitorProjectOnBuild";
+  public static final String FILE = "file";
+  public static final String ORGANISATION = "organisation";
+  public static final String PROJECT_NAME = "projectName";
+  public static final String ADDITIONAL_PARAMETERS = "additionalParameters";
+  public static final String API_TOKEN = "secure:apiToken";
+  public static final String VERSION = "version";
+  public static final String USE_CUSTOM_BUILD_TOOL_PATH = "useCustomBuildToolPath";
+  public static final String CUSTOM_BUILD_TOOL_PATH = "customBuildToolPath";
 
   public static final String SNYK_TEST_REPORT_JSON_FILE = "snyk_report.json";
   public static final String SNYK_MONITOR_REPORT_JSON_FILE = "snyk_monitor_report.json";

--- a/teamcity-snyk-security-plugin-server/src/assembly/teamcity-plugin-server.xml
+++ b/teamcity-snyk-security-plugin-server/src/assembly/teamcity-plugin-server.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <teamcity-plugin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:schemas-jetbrains-com:teamcity-plugin-v1-xml">
   <info>
-    <name>teamcity-snyk-security-plugin</name>
+    <name>snyk-security</name>
     <display-name>Snyk Security</display-name>
     <version>${revision}</version>
     <description>Adds the ability to test your code dependencies for vulnerabilities against Snyk database</description>


### PR DESCRIPTION
This PR solves remarks provided by Yegor:
1) plugin name in descriptor file
2) some minor issue in readme (missing links etc)
3) change id runner (this change **affects** existing installations -> builds have to be re-configured)
4) remove `snyk.` prefix from build step identifiers (this change **affects** existing installations -> builds have to be re-configured)