### PR TITLE
fix: improve platform detection on MacOS agents

### DIFF
--- a/teamcity-snyk-security-plugin-agent/src/main/java/io/snyk/plugins/teamcity/agent/commands/SnykBuildServiceAdapter.java
+++ b/teamcity-snyk-security-plugin-agent/src/main/java/io/snyk/plugins/teamcity/agent/commands/SnykBuildServiceAdapter.java
@@ -54,7 +54,7 @@ abstract class SnykBuildServiceAdapter extends BuildServiceAdapter {
 
   private Platform detectAgentPlatform() {
     BuildAgentSystemInfo buildAgentSystemInfo = getAgentConfiguration().getSystemInfo();
-    if (buildAgentSystemInfo.isUnix()) {
+    if (buildAgentSystemInfo.isUnix() && !buildAgentSystemInfo.isMac()) {
       return Platform.LINUX;
     } else if (buildAgentSystemInfo.isMac()) {
       return Platform.MAC_OS;


### PR DESCRIPTION
This PR fix platform detection on MacOS agents.
Sometimes (on certain versions e.g. Mojave) `BuildAgentSystemInfo.isUnix()` returns `true`.