### PR TITLE
fix: use jackson streaming api to process output from snyk test command

### DIFF
--- a/teamcity-snyk-security-plugin-agent/src/main/java/io/snyk/plugins/teamcity/agent/CommandExecutionAdapter.java
+++ b/teamcity-snyk-security-plugin-agent/src/main/java/io/snyk/plugins/teamcity/agent/CommandExecutionAdapter.java
@@ -7,7 +7,6 @@ import java.nio.file.Path;
 import java.util.List;
 
 import io.snyk.plugins.teamcity.common.ObjectMapperHelper;
-import io.snyk.plugins.teamcity.common.model.SnykApiResponse;
 import jetbrains.buildServer.BuildProblemData;
 import jetbrains.buildServer.RunBuildException;
 import jetbrains.buildServer.TeamCityRuntimeException;
@@ -106,8 +105,7 @@ public class CommandExecutionAdapter implements CommandExecution {
       }
 
       if (exitCode != 0) {
-        String commandOutput = new String(Files.readAllBytes(commandOutputPath), UTF_8);
-        ObjectMapperHelper.unmarshall(commandOutput, SnykApiResponse.class).ifPresent(snykApiResponse -> {
+        ObjectMapperHelper.unmarshall(commandOutputPath).ifPresent(snykApiResponse -> {
           // "error" indicates a hard error, so declare the build as failed
           if (nullIfEmpty(snykApiResponse.error) != null) {
             BuildProblemData buildProblem = createBuildProblem(snykApiResponse.error);

--- a/teamcity-snyk-security-plugin-common/src/main/java/io/snyk/plugins/teamcity/common/ObjectMapperHelper.java
+++ b/teamcity-snyk-security-plugin-common/src/main/java/io/snyk/plugins/teamcity/common/ObjectMapperHelper.java
@@ -1,30 +1,56 @@
 package io.snyk.plugins.teamcity.common;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.Optional;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
+import io.snyk.plugins.teamcity.common.model.SnykApiResponse;
 
 public final class ObjectMapperHelper {
 
-  private static final ObjectMapper OBJECT_MAPPER;
+  private static final JsonFactory JSON_FACTORY;
 
   static {
-    OBJECT_MAPPER = new ObjectMapper();
-    OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    JSON_FACTORY = new MappingJsonFactory();
   }
 
   private ObjectMapperHelper() {
   }
 
-  public static <T> Optional<T> unmarshall(String value, Class<T> clazz) throws IOException {
-    if (value != null && value.length() > 0) {
-      T result = OBJECT_MAPPER.readerFor(clazz).readValue(value.getBytes(StandardCharsets.UTF_8));
-      return Optional.ofNullable(result);
-    } else {
+  public static Optional<SnykApiResponse> unmarshall(Path path) throws IOException {
+    if (path == null) {
       return Optional.empty();
+    }
+
+    try (JsonParser parser = JSON_FACTORY.createParser(path.toFile())) {
+      if (parser.nextToken() != JsonToken.START_OBJECT) {
+        return Optional.empty();
+      }
+
+      SnykApiResponse snykApiResponse = new SnykApiResponse();
+
+      while (parser.nextToken() != JsonToken.END_OBJECT) {
+        String fieldName = parser.getCurrentName();
+
+        if ("summary".equals(fieldName)) {
+          parser.nextToken();
+          snykApiResponse.summary = parser.getText();
+        } else if ("error".equals(fieldName)) {
+          parser.nextToken();
+          snykApiResponse.error = parser.getText();
+        } else if ("uniqueCount".equals(fieldName)) {
+          parser.nextToken();
+          snykApiResponse.uniqueCount = parser.getIntValue();
+        } else {
+          parser.skipChildren();
+        }
+      }
+
+      return Optional.of(snykApiResponse);
     }
   }
 }


### PR DESCRIPTION
This PR fixes out of memory issue if output from snyk test command is huge (>300MB).

Now we don't read file into memory and parse it, instead we create a data stream and check needed fields only (`summary`, `error`, `uniqueCount`) and skip other fields.