### PR TITLE
fix: centralize dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,31 @@
     </plugins>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${version.jackson.databind}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.teamcity</groupId>
+        <artifactId>agent-api</artifactId>
+        <version>${version.teamcity}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.teamcity</groupId>
+        <artifactId>server-api</artifactId>
+        <version>${version.teamcity}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.teamcity.internal</groupId>
+        <artifactId>server</artifactId>
+        <version>${version.teamcity}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <modules>
     <module>teamcity-snyk-security-plugin-common</module>
     <module>teamcity-snyk-security-plugin-agent</module>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
      | dependency and plugin versions, please keep alphabetical.
      | each version property should be of the form "version.<identifier>".
     -->
-    <version.jackson.databind>2.9.9.1</version.jackson.databind>
+    <version.jackson.databind>2.9.9.3</version.jackson.databind>
     <version.maven.assembly.plugin>3.1.1</version.maven.assembly.plugin>
     <version.maven.clean.plugin>3.1.0</version.maven.clean.plugin>
     <version.maven.compiler.plugin>3.8.0</version.maven.compiler.plugin>

--- a/teamcity-snyk-security-plugin-agent/pom.xml
+++ b/teamcity-snyk-security-plugin-agent/pom.xml
@@ -17,7 +17,6 @@
     <dependency>
       <groupId>org.jetbrains.teamcity</groupId>
       <artifactId>agent-api</artifactId>
-      <version>${version.teamcity}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/teamcity-snyk-security-plugin-common/pom.xml
+++ b/teamcity-snyk-security-plugin-common/pom.xml
@@ -17,7 +17,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${version.jackson.databind}</version>
     </dependency>
   </dependencies>
 

--- a/teamcity-snyk-security-plugin-server/pom.xml
+++ b/teamcity-snyk-security-plugin-server/pom.xml
@@ -17,13 +17,11 @@
     <dependency>
       <groupId>org.jetbrains.teamcity</groupId>
       <artifactId>server-api</artifactId>
-      <version>${version.teamcity}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.teamcity.internal</groupId>
       <artifactId>server</artifactId>
-      <version>${version.teamcity}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This PR unifies and centralizes dependency versions management in child submodules, so dependencies in submodules don't need version tag anymore.
http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management