### PR TITLE
Upgrade jackson-databind dependency to version 2.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
      | dependency and plugin versions, please keep alphabetical.
      | each version property should be of the form "version.<identifier>".
     -->
-    <version.jackson.databind>2.10.0.pr1</version.jackson.databind>
+    <version.jackson.databind>2.10.1</version.jackson.databind>
     <version.maven.assembly.plugin>3.1.1</version.maven.assembly.plugin>
     <version.maven.clean.plugin>3.1.0</version.maven.clean.plugin>
     <version.maven.compiler.plugin>3.8.0</version.maven.compiler.plugin>


### PR DESCRIPTION
This PR upgrades `jackson-databind` dependency to version `2.10.1` (latest at 31.12.2019).