### PR TITLE
chore: upgrade maven wrapper

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,12 @@ services:
     image: "jetbrains/teamcity-server:2018.2.3"
     ports:
       - "${TC_PORT:-8111}:8111"
+      - "${TC_DEBUG_PORT:-8222}:8222"
     volumes:
       - "./distribution/docker/server:/data/teamcity_server/datadir"
     environment:
-      - TEAMCITY_SERVER_MEM_OPTS=-Xmx4096m
+      - JAVA_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,address=8222,suspend=n
+      - TEAMCITY_SERVER_MEM_OPTS=-Xmx3072m
 
   agent:
     image: "jetbrains/teamcity-agent:2018.2.3"


### PR DESCRIPTION
This PR upgrades Maven version to `3.6.3`.
P.S.: Previous version (3.6.0) had some issues by dependencies resolution inside of IntelliJ.