### PR TITLE
chore(ci): prevent 'empty' releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,44 @@ on:
     - cron: '0 9 * * 2'  # every Tuesday at 9 am UTC
 
 jobs:
-  release:
-    name: release
+  check:
+    name: Check for changes
     runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check_changes.outputs.has_changes }}
+    steps:
+      - name: Fetch Sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes since last release
+        id: check_changes
+        run: |
+          # Get the latest release tag
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No previous release found. Will create initial release."
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            # Count commits since the last tag
+            COMMIT_COUNT=$(git rev-list ${LATEST_TAG}..HEAD --count)
+            
+            if [ "$COMMIT_COUNT" -gt 0 ]; then
+              echo "Found $COMMIT_COUNT commits since $LATEST_TAG. Will create release."
+              echo "has_changes=true" >> $GITHUB_OUTPUT
+            else
+              echo "No changes since $LATEST_TAG. Skipping release."
+              echo "has_changes=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: check
+    if: needs.check.outputs.has_changes == 'true'
     steps:
       - name: Fetch Sources
         uses: actions/checkout@v3


### PR DESCRIPTION
### Why This Change is Necessary

Currently, the scheduled job in our GitHub Actions release workflow runs every Tuesday at 9 am UTC and **always creates a new release tag and deployment**, even if no code changes have been merged since the last successful release.

This leads to:

* **Noise in the Releases tab:** Creating unnecessary release tags that point to the same commit as the previous release.
* **Unnecessary Artifact Uploads:** Uploading identical binaries to the JetBrains portal repeatedly.

### What This Change Does

This PR introduces a check to ensure the release workflow only proceeds when there are actual changes to be released.

#### 1. Conditional Release Logic

A new dedicated job, `check`, has been introduced. This job performs the following:

* It finds the most recent git tag (`LATEST_TAG`).
* It uses `git rev-list ${LATEST_TAG}..HEAD --count` to count the number of commits between the latest tag and the current `HEAD`.
* If the commit count is greater than zero, it sets the `has_changes` output to `true`. Otherwise, it sets it to `false`.

#### 2. Workflow Orchestration

The original `release` job is now dependent on the new `check` job:

* It uses `needs: check` to wait for the result of the check.
* It uses a conditional `if: needs.check.outputs.has_changes == 'true'` to ensure all subsequent build and deployment steps are skipped entirely if no changes are detected.

**Result:** The scheduled workflow will now run every Tuesday, quickly execute the `check` job, and then terminate immediately if there are no new commits, saving time and cleaning up our release history.

Reference: https://snyksec.atlassian.net/browse/CLI-806