### PR TITLE
fix: sanitize embedded Snyk HTML report and encode errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@
     <version.maven.resources.plugin>3.1.0</version.maven.resources.plugin>
     <version.maven.site.plugin>3.7.1</version.maven.site.plugin>
     <version.maven.surefire.plugin>3.0.0-M3</version.maven.surefire.plugin>
+    <version.owasp.encoder>1.4.0</version.owasp.encoder>
+    <version.owasp.java.html.sanitizer>20260101.1</version.owasp.java.html.sanitizer>
     <version.teamcity>2024.07</version.teamcity>
   </properties>
 
@@ -154,6 +156,16 @@
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-engine</artifactId>
         <version>${version.junit5}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+        <artifactId>owasp-java-html-sanitizer</artifactId>
+        <version>${version.owasp.java.html.sanitizer}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.owasp.encoder</groupId>
+        <artifactId>encoder</artifactId>
+        <version>${version.owasp.encoder}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/teamcity-snyk-security-plugin-common/src/main/java/io/snyk/plugins/teamcity/common/ObjectMapperHelper.java
+++ b/teamcity-snyk-security-plugin-common/src/main/java/io/snyk/plugins/teamcity/common/ObjectMapperHelper.java
@@ -48,7 +48,7 @@ public final class ObjectMapperHelper {
     SnykTestStatus snykTestStatus = new SnykTestStatus();
 
     while (parser.nextToken() != JsonToken.END_OBJECT) {
-      String fieldName = parser.getCurrentName();
+      String fieldName = parser.currentName();
 
       if ("ok".equals(fieldName)) {
         parser.nextToken();

--- a/teamcity-snyk-security-plugin-server/pom.xml
+++ b/teamcity-snyk-security-plugin-server/pom.xml
@@ -29,6 +29,24 @@
       <artifactId>teamcity-snyk-security-plugin-common</artifactId>
       <version>${revision}</version>
     </dependency>
+    <dependency>
+      <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+      <artifactId>owasp-java-html-sanitizer</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.owasp.encoder</groupId>
+      <artifactId>encoder</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/teamcity-snyk-security-plugin-server/src/main/java/io/snyk/plugins/teamcity/server/SnykReportHtmlSanitizer.java
+++ b/teamcity-snyk-security-plugin-server/src/main/java/io/snyk/plugins/teamcity/server/SnykReportHtmlSanitizer.java
@@ -1,0 +1,56 @@
+package io.snyk.plugins.teamcity.server;
+
+import java.util.Objects;
+
+import org.jetbrains.annotations.NotNull;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
+import org.owasp.html.Sanitizers;
+
+/**
+ * Sanitizes HTML produced by snyk-to-html (and embedded in the TeamCity UI). The artifact must be
+ * treated as untrusted because CLI JSON can influence report HTML (e.g. markdown via marked).
+ */
+public final class SnykReportHtmlSanitizer {
+
+  /**
+   * Composed policies from OWASP {@link Sanitizers}; an extra policy adds safe semantic tags and
+   * {@code data-*} attributes used by snyk-to-html templates.
+   */
+  private static final PolicyFactory POLICY =
+      Objects.requireNonNull(Sanitizers.FORMATTING)
+          .and(Objects.requireNonNull(Sanitizers.BLOCKS))
+          .and(Objects.requireNonNull(Sanitizers.STYLES))
+          .and(Objects.requireNonNull(Sanitizers.LINKS))
+          .and(Objects.requireNonNull(Sanitizers.TABLES))
+          .and(Objects.requireNonNull(Sanitizers.IMAGES))
+          .and(
+              Objects.requireNonNull(
+                  new HtmlPolicyBuilder()
+                      .allowElements(
+                          "pre",
+                          "hr",
+                          "main",
+                          "header",
+                          "footer",
+                          "section",
+                          "article",
+                          "nav",
+                          "aside",
+                          "figure",
+                          "figcaption",
+                          "details",
+                          "summary")
+                      .allowAttributes("class", "id", "role", "lang", "dir")
+                      .globally()
+                      .allowAttributes("data-pane", "data-toggle")
+                      .globally()
+                      .toFactory()));
+
+  private SnykReportHtmlSanitizer() {}
+
+  @NotNull
+  public static String sanitize(@NotNull String html) {
+    return POLICY.sanitize(html);
+  }
+}

--- a/teamcity-snyk-security-plugin-server/src/main/java/io/snyk/plugins/teamcity/server/SnykSecurityReportTab.java
+++ b/teamcity-snyk-security-plugin-server/src/main/java/io/snyk/plugins/teamcity/server/SnykSecurityReportTab.java
@@ -20,6 +20,7 @@ import jetbrains.buildServer.web.openapi.PositionConstraint;
 import jetbrains.buildServer.web.openapi.ViewLogTab;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.owasp.encoder.Encode;
 
 import static io.snyk.plugins.teamcity.common.SnykSecurityRunnerConstants.SNYK_ARTIFACTS_DIR;
 import static io.snyk.plugins.teamcity.common.SnykSecurityRunnerConstants.SNYK_REPORT_HTML_FILE;
@@ -58,27 +59,31 @@ public class SnykSecurityReportTab extends ViewLogTab {
   private String readSnykHtmlReport(@NotNull SBuild build) {
     String snykHtmlReportPath = TEAMCITY_ARTIFACTS_DIR + separator + SNYK_ARTIFACTS_DIR + separator + SNYK_REPORT_HTML_FILE;
     BuildArtifact artifact = build.getArtifacts(BuildArtifactsViewMode.VIEW_HIDDEN_ONLY).getArtifact(snykHtmlReportPath);
+    String htmlContent;
 
     if (artifact == null) {
       LOG.error("An error occurred while reading the Snyk HTML report - artifact not found");
-      return generateErrorMessage("Artifact not found");
+      htmlContent = generateErrorMessage("Artifact not found");
+    } else {
+      try (InputStream inputStream = artifact.getInputStream();
+           BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+        StringBuilder content = new StringBuilder();
+        String line;
+        while ((line = reader.readLine()) != null) {
+          content.append(line).append("\n");
+        }
+        htmlContent = content.toString();
+      } catch (IOException e) {
+        LOG.error("An error occurred while reading the Snyk HTML report.", e);
+        htmlContent = generateErrorMessage("An error occurred while reading the report");
+      }
     }
 
-    try (InputStream inputStream = artifact.getInputStream();
-         BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
-      StringBuilder content = new StringBuilder();
-      String line;
-      while ((line = reader.readLine()) != null) {
-        content.append(line).append("\n");
-      }
-      return content.toString();
-    } catch (IOException e) {
-      LOG.error("An error occurred while reading the Snyk HTML report.", e);
-      return generateErrorMessage("An error occurred while reading the report");
-    }
+    return SnykReportHtmlSanitizer.sanitize(htmlContent);
   }
 
   private String generateErrorMessage(String message) {
-    return "<html><head><title>Error</title></head><body><h1>Snyk report error: " + message + "</h1></body></html>";
+    String safeMessage = Encode.forHtml(message);
+    return "<h1>Snyk report error: " + safeMessage + "</h1>";
   }
 }

--- a/teamcity-snyk-security-plugin-server/src/main/resources/buildServerResources/tab/snykReport.jsp
+++ b/teamcity-snyk-security-plugin-server/src/main/resources/buildServerResources/tab/snykReport.jsp
@@ -7,6 +7,7 @@
 </c:if>
 
 <c:if test="${empty error}">
+  <%-- snykHtmlReportContent is sanitized server-side (SnykReportHtmlSanitizer) before inclusion --%>
   <div>
       ${snykHtmlReportContent}
   </div>

--- a/teamcity-snyk-security-plugin-server/src/test/java/io/snyk/plugins/teamcity/server/SnykReportHtmlSanitizerTest.java
+++ b/teamcity-snyk-security-plugin-server/src/test/java/io/snyk/plugins/teamcity/server/SnykReportHtmlSanitizerTest.java
@@ -1,0 +1,90 @@
+package io.snyk.plugins.teamcity.server;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SnykReportHtmlSanitizerTest {
+
+  @Test
+  void removesImgOnerrorFromSnykToHtmlStylePayload() {
+    String malicious = "<hr/><!-- Overview --><img src=x onerror=\"alert(1)\">";
+    String safe = SnykReportHtmlSanitizer.sanitize(malicious);
+    assertFalse(safe.toLowerCase().contains("onerror"));
+    assertFalse(safe.contains("alert(1)"));
+  }
+
+  @Test
+  void stripsScriptTags() {
+    String malicious = "<div>hi<script>alert(1)</script></div>";
+    String safe = SnykReportHtmlSanitizer.sanitize(malicious);
+    assertFalse(safe.toLowerCase().contains("<script"));
+    assertFalse(safe.contains("alert(1)"));
+  }
+
+  @Test
+  void neutralizesJavascriptInHref() {
+    String malicious = "<a href=\"javascript:alert(1)\">click</a>";
+    String safe = SnykReportHtmlSanitizer.sanitize(malicious);
+    assertFalse(safe.toLowerCase().contains("javascript:"));
+  }
+
+  @Test
+  void preservesBenignReportLikeMarkup() {
+    String html =
+        "<html><head><title>Report</title><style>body{font-size:12px;}</style></head>"
+            + "<body><div class=\"card\"><table><tr><th>Sev</th></tr><tr><td>high</td></tr></table>"
+            + "<a href=\"https://example.com/issue\">link</a></div></body></html>";
+    String safe = SnykReportHtmlSanitizer.sanitize(html);
+    assertTrue(safe.contains("<table"));
+    assertTrue(safe.contains("https://example.com/issue"));
+    assertTrue(safe.contains("<div"));
+  }
+
+  @Test
+  void stripsDataUriJavascriptPayload() {
+    String malicious = "<a href=\"data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==\">click</a>";
+    String safe = SnykReportHtmlSanitizer.sanitize(malicious);
+    assertFalse(safe.toLowerCase().contains("data:"));
+  }
+
+  @Test
+  void stripsMetaRefreshRedirect() {
+    String malicious = "<meta http-equiv=\"refresh\" content=\"0;url=https://evil.com/phishing\">";
+    String safe = SnykReportHtmlSanitizer.sanitize(malicious);
+    assertFalse(safe.toLowerCase().contains("<meta"));
+    assertFalse(safe.contains("evil.com"));
+  }
+
+  @Test
+  void stripsStyleAndLinkTags() {
+    String malicious =
+        "<style>body{display:none}</style><link rel=\"stylesheet\" href=\"https://evil.com/x.css\">";
+    String safe = SnykReportHtmlSanitizer.sanitize(malicious);
+    assertFalse(safe.toLowerCase().contains("<style"));
+    assertFalse(safe.toLowerCase().contains("<link"));
+    assertFalse(safe.contains("evil.com"));
+  }
+
+  @Test
+  void stripsDocumentShellElementsWhenEmbedded() {
+    String html = "<html><head><title>t</title></head><body><main>safe-content</main></body></html>";
+    String safe = SnykReportHtmlSanitizer.sanitize(html);
+    assertFalse(safe.toLowerCase().contains("<html"));
+    assertFalse(safe.toLowerCase().contains("<head"));
+    assertFalse(safe.toLowerCase().contains("<body"));
+    assertTrue(safe.contains("safe-content"));
+  }
+
+  @Test
+  void sanitizeCompletesForLargeInput() {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 500; i++) {
+      sb.append("<p>line ").append(i).append("</p>");
+    }
+    String html = sb.toString();
+    assertDoesNotThrow(() -> SnykReportHtmlSanitizer.sanitize(html));
+  }
+}


### PR DESCRIPTION
This PR:
* Sanitizes snyk_report.html on the server before it is shown in the Snyk Security Report tab, so untrusted markup cannot run in the browser. 
* Error text in the small HTML error path is encoded with OWASP Java Encoder (Encode.forHtml). 
* Adds OWASP Java HTML Sanitizer
* Unit tests
* A short JSP note that content is sanitized server-side.

The TeamCity build agent runs `snyk test --json` and then `snyk-to-html` with only `-i` / `-o`, so this integration always uses the [default](https://github.com/snyk/snyk-to-html/blob/b0d01e3c82201750327aadac2a734e1d799640de/template/test-report.hbs) template that does not include the _inline-js_ script block. Given that flow, what users see in the report tab for normal builds should stay the same as before this change

